### PR TITLE
Use $owner to run git commands so they get their environment (SSH Keys)

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -46,6 +46,7 @@ define git::repo(
 
 	exec {"git_repo_${name}":
 		command	=> $init_cmd,
+        user => $owner,
 		creates	=> $creates,
 		require => Package[$git::params::package],
 		notify	=> File[$path],


### PR DESCRIPTION
Since the git commands were being run as puppet/root the repositories couldn't be checked out from our git server. Enabling the $owner to run the command solved the issue. This seems like good default behaviour.
