### PR TITLE
Puppet exec changes break git::user creation

### DIFF
--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -37,6 +37,7 @@ define git::user(
     command => "/bin/su ${name} -c '${git::params::bin} config --global user.name \"${git_name}\"'",
     unless  => "/bin/su ${name} -c '${git::params::bin} config --global user.name'|/bin/grep '${git_name}'",
     require => [Package[$git::params::package]],
+    provider => "shell",
   }
 
   exec{"${name}_git_email":


### PR DESCRIPTION
With newer versions of puppet exec calls have their environments stripped.  Most importantly the $HOME is removed.  As a result git::user resources fail.

However puppet did add a shell provider to the exec provider system that maintains these environment variables.

Switch git::user to use the shell provider for exec.

Question, how does this affect prior versions of puppet and this module?
