### PR TITLE
Fix creation of bare repository

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -80,7 +80,7 @@ define git::repo(
       unless  => "${git::params::bin} describe --tag|/bin/grep -P '${git_tag}'",
       require => Exec["git_repo_${name}"],
     }
-  } else {
+  } elsif ! $bare {
     exec {"git_${name}_co_branch":
       user    => $owner,
       cwd     => $path,


### PR DESCRIPTION
If the repository is bare, it shouldn't checkout any branch, as this causes the following error:

```
err: /Stage[main]/Project/Git::Repo[project]/Exec[git_project_co_branch]/returns: change from notrun to 0 failed: /usr/bin/git checkout  returned 128 instead of one of [0] at .../puppet-git/manifests/repo.pp:90
```
