### PR TITLE
Fix updating git repo

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -92,7 +92,7 @@ define git::repo(
       exec {"git_${name}_pull":
         user    => $owner,
         cwd     => $path,
-        command => "${git::params::bin} reset --hard HEAD && ${git::params::bin} pull origin ${branch}",
+        command => "${git::params::bin} reset --hard origin/${branch}",
         unless  => "${git::params::bin} fetch && ${git::params::bin} diff origin --no-color --exit-code",
         require => Exec["git_repo_${name}"],
       }


### PR DESCRIPTION
Without these changes, even when passing `update => true` to `git::repo`, the repo would not update because changes from origin were not being fetched before checking the diff, so I have made this explicit in the `unless` attribute.

I also updated the `command` attribute to just `reset --hard` to the origin branch (rather than pulling, which could potentially cause merge conflicts) to ensure the repo is always in the correct state.
