### PR TITLE
Add 'Scientific' to operatingsystem case

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,7 +5,7 @@
 class git::params {
 
   case $::operatingsystem {
-    'CentOS','Ubuntu', 'Debian', 'Amazon', 'Archlinux', 'Gentoo' :{
+    'Scientific','CentOS','Ubuntu', 'Debian', 'Amazon', 'Archlinux', 'Gentoo' :{
       $svn_package  = 'git-svn'
       $gui_package  = 'git-gui'
       $bin          = '/usr/bin/git'


### PR DESCRIPTION
Converted Centos -> Scientific linux and had issues using your git module. Added 'Scientific' to the existing cases in params.pp and it succeeded without issues.

Thanks for your code and hope this helps other SciLinux users.
