### PR TITLE
Could not set User for git since the check used grep_bin instead of grep_cmd

### DIFF
--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -35,13 +35,13 @@ define git::user(
 
   exec{"${name}_git_name":
     command => "/bin/su - ${name} -c '${git::params::bin} config --global user.name \"${git_name}\"'",
-    unless  => "/bin/su - ${name} -c '${git::params::bin} config --global user.name'|${git::params::grep_bin} '${git_name}'",
+    unless  => "/bin/su - ${name} -c '${git::params::bin} config --global user.name'|${git::params::grep_cmd} '${git_name}'",
     require => [Package[$git::params::package]],
   }
 
   exec{"${name}_git_email":
     command => "/bin/su - ${name} -c '${git::params::bin} config --global user.email \"${git_email}\"'",
-    unless  => "/bin/su - ${name} -c '${git::params::bin} config --global user.email'|${git::params::grep_bin} '${git_email}'",
+    unless  => "/bin/su - ${name} -c '${git::params::bin} config --global user.email'|${git::params::grep_cmd} '${git_email}'",
     require => [Package[$git::params::package]],
   }
 


### PR DESCRIPTION
Not sure if moving the variables out of binaries caused this: fb191c310f83c7f552f6d5a4dfeb803c44f6ca54 to actually be a problem

Or if the original refactoring to use the right path for ArchLinux: 8bda888fb6fad844fff563919a4b51a28a51279a never actually worked for user.pp
