### PR TITLE
removed -P grep option: useless and does not work if libpcre unavailable

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -77,7 +77,7 @@ define git::repo(
       user    => $owner,
       cwd     => $path,
       command => "${git::params::bin} checkout ${git_tag}",
-      unless  => "${git::params::bin} describe --tag|${git::params::grep_cmd} -P '${git_tag}'",
+      unless  => "${git::params::bin} describe --tag|${git::params::grep_cmd} '${git_tag}'",
       require => Exec["git_repo_${name}"],
     }
   } elsif ! $bare {
@@ -85,7 +85,7 @@ define git::repo(
       user    => $owner,
       cwd     => $path,
       command => "${git::params::bin} checkout ${branch}",
-      unless  => "${git::params::bin} branch|${git::params::grep_cmd} -P '\\* ${branch}'",
+      unless  => "${git::params::bin} branch|${git::params::grep_cmd} '\\* ${branch}'",
       require => Exec["git_repo_${name}"],
     }
     if $update {


### PR DESCRIPTION
If libpcre.so.3 is not available, then grep -P produces an error
when checking if checkout is needed. This option had some sense
when the search term was surrounded with ^ and $ (removed in 899dad).
It looks useless now. Maybe should use -w instead?
