### PR TITLE
running clone without sudo as it is redundant

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -47,12 +47,12 @@ define git::repo(
   }
 
   if $source {
-    $init_cmd = "${su_do}${git::params::bin} clone -b ${real_branch} ${source} ${path} --recursive${su_end}"
+    $init_cmd = "${git::params::bin} clone -b ${real_branch} ${source} ${path} --recursive"
   } else {
     if $bare {
-      $init_cmd = "${su_do}${git::params::bin} init --bare ${path}${su_end}"
+      $init_cmd = "${git::params::bin} init --bare ${path}"
     } else {
-      $init_cmd = "${su_do}${git::params::bin} init ${path}${su_end}"
+      $init_cmd = "${git::params::bin} init ${path}"
     }
   }
 


### PR DESCRIPTION
Running `git clone` and `su` and also running `exec` as the owner passed does not work as the owner might not be able to `su` to himself. But either way a `su` wrapper is not needed as puppet takes care of that.
