### PR TITLE
Added quotes to OS cases

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,7 +11,7 @@ class git::params {
   $su_cmd       = '/bin/su'
 
   case $::osfamily {
-    Debian: {
+    'Debian': {
       if $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '11') < 0 {
         $package = 'git-core'
       }else{
@@ -19,11 +19,11 @@ class git::params {
       }
       $grep_cmd =  '/bin/grep'
     }
-    RedHat: {
+    'RedHat': {
       $package = 'git'
       $grep_cmd = '/bin/grep'
     }
-    ArchLinux:{
+    'ArchLinux':{
       $package = 'git'
       $grep_cmd = '/usr/bin/grep'
     }


### PR DESCRIPTION
Sorry for not putting this on the 'pull_here' branch but it looks like that one is out of date and would have conflicts. On a fresh install of the latest debian, latest puppet, etc, i get an error that Debian is not supported without these quotes.